### PR TITLE
RESOLVE #TODO: update docker entry script to allow SIGINT to graceful…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ WORKDIR /data
 EXPOSE 27017
 EXPOSE 28017
 
+# make sure that mongod performs a clean shutdown
+# when container is stopped
+STOPSIGNAL SIGINT
+
 #ENTRYPOINT ["/sbin/tini", "--"]
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["mongod"] 


### PR DESCRIPTION
…ly stop MongoDB on stop/restart container.

This simple change resolves the TODO in the README file.