### PR TITLE
Fixed the restarting with exit status 100 issue

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+if [ -f /data/db/mongod.lock ]; then
+    echo "Old mongod.lock file found! Removing..."
+    sudo rm /data/db/mongod.lock
+    echo "Removed successfully!"
+else
+    echo "No old mongod.lock file found, starting normally..."
+fi
+
 trap 'kill -2 1; wait 1' SIGTERM
 
 # if [ "$1" = 'mongod' ]; then


### PR DESCRIPTION
Hey, I added some code in your docker-entrypoint.sh to check if the mongod.lock file exists in the /data/db directory. If it exists, that file is removed with: 

`sudo rm /data/db/mongod.lock`

If this lock file exists, mongoDB assumes an instance of it is already running, therefore it exits with status 100. I tested this fix on my pi by building the image with your instructions, and I am not having restart issues anymore. Hope this helps someone!